### PR TITLE
Preserve H2 cookie

### DIFF
--- a/client.go
+++ b/client.go
@@ -1154,6 +1154,18 @@ func (c *Client) SetTLSFingerprintRandomized() *Client {
 	return c.SetTLSFingerprint(utls.HelloRandomized)
 }
 
+// EnablePreserveCookie prevents transport from modifying the request cookie.
+func (c *Client) EnablePreserveCookie() *Client {
+	c.Transport.EnablePreserveCookie()
+	return c
+}
+
+// DisablePreserveCookies allows transport to modify the request cookie.
+func (c *Client) DisablePreserveCookie() *Client {
+	c.Transport.DisablePreserveCookie()
+	return c
+}
+
 // uTLSConn is wrapper of UConn which implements the net.Conn interface.
 type uTLSConn struct {
 	*utls.UConn

--- a/client_test.go
+++ b/client_test.go
@@ -5,9 +5,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"github.com/imroc/req/v3/internal/header"
-	"github.com/imroc/req/v3/internal/tests"
-	"golang.org/x/net/publicsuffix"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +14,10 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/imroc/req/v3/internal/header"
+	"github.com/imroc/req/v3/internal/tests"
+	"golang.org/x/net/publicsuffix"
 )
 
 func TestWrapRoundTrip(t *testing.T) {
@@ -647,4 +648,9 @@ func TestCloneCookieJar(t *testing.T) {
 	c2.SetCookieJar(nil)
 	tests.AssertEqual(t, true, c2.cookiejarFactory == nil)
 	tests.AssertEqual(t, true, c2.httpClient.Jar == nil)
+}
+
+func TestEnablePreserveCookie(t *testing.T) {
+	c := tc().EnablePreserveCookie()
+	tests.AssertEqual(t, true, c.Transport.PreserveCookie)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -653,4 +653,6 @@ func TestCloneCookieJar(t *testing.T) {
 func TestEnablePreserveCookie(t *testing.T) {
 	c := tc().EnablePreserveCookie()
 	tests.AssertEqual(t, true, c.Transport.PreserveCookie)
+	c.DisablePreserveCookie()
+	tests.AssertEqual(t, false, c.Transport.PreserveCookie)
 }

--- a/internal/http2/transport.go
+++ b/internal/http2/transport.go
@@ -1969,7 +1969,7 @@ func (cc *ClientConn) encodeHeaders(req *http.Request, addGzipHeader bool, trail
 				if vv[0] == "" {
 					continue
 				}
-			} else if ascii.EqualFold(k, "cookie") {
+			} else if !cc.t.PreserveCookie && ascii.EqualFold(k, "cookie") {
 				var vals []string
 				// Per 8.1.2.5 To allow for better compression efficiency, the
 				// Cookie header field MAY be split into separate header fields,

--- a/internal/transport/option.go
+++ b/internal/transport/option.go
@@ -3,11 +3,12 @@ package transport
 import (
 	"context"
 	"crypto/tls"
-	"github.com/imroc/req/v3/internal/dump"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/imroc/req/v3/internal/dump"
 )
 
 // Options is transport's options.
@@ -152,6 +153,12 @@ type Options struct {
 
 	// Debugf is the optional debug function.
 	Debugf func(format string, v ...interface{})
+
+	// PreserveCookie determines whether the cookie header should
+	// preserve original formatting or whether the internal transport
+	// will split a single cookie header into separate header fields
+	// for compression efficiency.
+	PreserveCookie bool
 
 	Dump *dump.Dumper
 }

--- a/transport.go
+++ b/transport.go
@@ -499,6 +499,20 @@ func (t *Transport) SetTLSHandshake(fn func(ctx context.Context, addr string, pl
 	return t
 }
 
+// EnablePreserveCookie preserves original request formatting for
+// cookie headers.
+func (t *Transport) EnablePreserveCookie() *Transport {
+	t.PreserveCookie = true
+	return t
+}
+
+// DisablePreserveCookie allows the transport to rewrite headers for
+// compression efficiency.
+func (t *Transport) DisablePreserveCookie() *Transport {
+	t.PreserveCookie = false
+	return t
+}
+
 type pendingAltSvc struct {
 	CurrentIndex int
 	Entries      []*altsvc.AltSvc


### PR DESCRIPTION
Certain websites will use the cookie header for signature verification.

The default behavior of splitting the cookie in the H2 path will interfere with this and cause websites to fail in a mysterious way.