### PR TITLE
BC-17507

### DIFF
--- a/internal/http3/transport.go
+++ b/internal/http3/transport.go
@@ -121,7 +121,10 @@ var (
 )
 
 // ErrNoCachedConn is returned when Transport.OnlyCachedConn is set
-var ErrNoCachedConn = errors.New("http3: no cached connection was available")
+var (
+	ErrNoCachedConn     = errors.New("http3: no cached connection was available")
+	ErrNilNewClientConn = errors.New("http3: newClientConn is nil")
+)
 
 func (t *Transport) init() error {
 	if t.newClientConn == nil {
@@ -305,6 +308,11 @@ func (t *Transport) AddConn(ctx context.Context, addr string) error {
 }
 
 func (t *Transport) getClient(ctx context.Context, hostname string, onlyCached bool) (rtc *roundTripperWithCount, isReused bool, err error) {
+	t.initOnce.Do(func() { t.initErr = t.init() })
+	if t.initErr != nil {
+		return nil, false, t.initErr
+	}
+
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -401,6 +409,10 @@ func (t *Transport) dial(ctx context.Context, hostname string) (*quic.Conn, clie
 	conn, err := dial(ctx, hostname, tlsConf, t.QUICConfig)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	if t.newClientConn == nil {
+		return nil, nil, ErrNilNewClientConn
 	}
 	return conn, t.newClientConn(conn), nil
 }


### PR DESCRIPTION
Fixes:

```
goroutine 104066 [running]:
github.com/imroc/req/v3/internal/http3.(*Transport).dial(0xc011eeda40, {0x3934360, 0xc0101b8140}, {0xc0135c1ed8, 0x11})
        /go/pkg/mod/github.com/banyansecurity/req/v3@v3.0.0-20250801185154-326e9f9d3b31/internal/http3/transport.go:405 +0x21a
github.com/imroc/req/v3/internal/http3.(*Transport).getClient.func1()
        /go/pkg/mod/github.com/banyansecurity/req/v3@v3.0.0-20250801185154-326e9f9d3b31/internal/http3/transport.go:328 +0x71
created by github.com/imroc/req/v3/internal/http3.(*Transport).getClient in goroutine 104083
        /go/pkg/mod/github.com/banyansecurity/req/v3@v3.0.0-20250801185154-326e9f9d3b31/internal/http3/transport.go:325 +0x292
```